### PR TITLE
SSL Certificate Verification

### DIFF
--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -82,6 +82,12 @@ class Client
         'Content-Type: application/json',
         'Accept: application/json'
     );
+    /**
+     * SSL certificates verification
+     * @access public
+     * @var boolean
+     */
+    public $ssl_verify_peer = true;
 
     /**
      * Constructor
@@ -288,6 +294,7 @@ class Client
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->headers);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->ssl_verify_peer);
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
 
         if ($this->username && $this->password) {


### PR DESCRIPTION
Allow control of `CURLOPT_SSL_VERIFYPEER`

Set ´$ssl_verify_peer´ to false in order to skip verification
And use self-signed Certificates