### PR TITLE
Fix ssl verification with fopen

### DIFF
--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -99,7 +99,7 @@ class Client
     /**
      * SSL certificates verification
      *
-     * @access private
+     * @access public
      * @var boolean
      */
     public $ssl_verify_peer = true;
@@ -345,8 +345,11 @@ class Client
                 'max_redirects' => 2,
                 'header' => implode("\r\n", $headers),
                 'content' => json_encode($payload),
-                'verify_peer' => $this->ssl_verify_peer,
                 'ignore_errors' => true,
+            ),
+            "ssl" => array(
+                "verify_peer" => $this->ssl_verify_peer,
+                "verify_peer_name" => $this->ssl_verify_peer,
             )
         ));
     }


### PR DESCRIPTION
https certificate verification with fopen should be located under the 'ssl' section of the context. This pull request fixes that for https. 

Note: I have not tested this with an http endpoint. 