### PR TITLE
Handle when json is unable to encode response

### DIFF
--- a/src/JsonRPC/Server.php
+++ b/src/JsonRPC/Server.php
@@ -314,12 +314,12 @@ class Server
         $response = array_merge($response, $data);
 
         @header('Content-Type: application/json');
+
         $encodedResponse = json_encode($response);
-        if(!$encodedResponse)
+        $jsonError = json_last_error();
+        if($jsonError !== JSON_ERROR_NONE)
         {
-            $error = json_last_error();
-            $errorMessage = 'Unknown';
-            switch (json_last_error()) {
+            switch ($jsonError) {
                 case JSON_ERROR_NONE:
                     $errorMessage = 'No errors';
                     break;
@@ -342,7 +342,7 @@ class Server
                     $errorMessage = 'Unknown error';
                     break;
             }
-            throw new ResponseEncodingFailure($errorMessage,$error);
+            throw new ResponseEncodingFailure($errorMessage,$jsonError);
         }
         return $encodedResponse;
     }

--- a/src/JsonRPC/Server.php
+++ b/src/JsonRPC/Server.php
@@ -13,6 +13,7 @@ use ReflectionMethod;
 class InvalidJsonRpcFormat extends Exception {};
 class InvalidJsonFormat extends Exception {};
 class AuthenticationFailure extends Exception {};
+class ResponseEncodingFailure extends Exception {};
 
 /**
  * JsonRPC server class
@@ -294,9 +295,10 @@ class Server
      * Return the response to the client
      *
      * @access public
-     * @param  array    $data      Data to send to the client
-     * @param  array    $payload   Incoming data
+     * @param  array $data Data to send to the client
+     * @param  array $payload Incoming data
      * @return string
+     * @throws ResponseEncodingFailure
      */
     public function getResponse(array $data, array $payload = array())
     {
@@ -312,7 +314,37 @@ class Server
         $response = array_merge($response, $data);
 
         @header('Content-Type: application/json');
-        return json_encode($response);
+        $encodedResponse = json_encode($response);
+        if(!$encodedResponse)
+        {
+            $error = json_last_error();
+            $errorMessage = 'Unknown';
+            switch (json_last_error()) {
+                case JSON_ERROR_NONE:
+                    $errorMessage = 'No errors';
+                    break;
+                case JSON_ERROR_DEPTH:
+                    $errorMessage = 'Maximum stack depth exceeded';
+                    break;
+                case JSON_ERROR_STATE_MISMATCH:
+                    $errorMessage = 'Underflow or the modes mismatch';
+                    break;
+                case JSON_ERROR_CTRL_CHAR:
+                    $errorMessage = 'Unexpected control character found';
+                    break;
+                case JSON_ERROR_SYNTAX:
+                    $errorMessage = 'Syntax error, malformed JSON';
+                    break;
+                case JSON_ERROR_UTF8:
+                    $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+                    break;
+                default:
+                    $errorMessage = 'Unknown error';
+                    break;
+            }
+            throw new ResponseEncodingFailure($errorMessage,$error);
+        }
+        return $encodedResponse;
     }
 
     /**
@@ -453,6 +485,16 @@ class Server
                 'error' => array(
                     'code' => -32602,
                     'message' => 'Invalid params'
+                )),
+                $this->payload
+            );
+        }
+        catch(ResponseEncodingFailure $e){
+            return $this->getResponse(array(
+                'error' => array(
+                    'code' => -32603,
+                    'message' => 'Internal error',
+                    'data' => $e->getMessage()
                 )),
                 $this->payload
             );

--- a/tests/ServerProcedureTest.php
+++ b/tests/ServerProcedureTest.php
@@ -143,6 +143,6 @@ class ServerProcedureTest extends PHPUnit_Framework_TestCase
     public function testInvalidResponse()
     {
         $server = new Server;
-        $server->getResponse([pack("H*", 'c32e')],array('id'=>1));
+        $server->getResponse(array(pack("H*", 'c32e')),array('id'=>1));
     }
 }

--- a/tests/ServerProcedureTest.php
+++ b/tests/ServerProcedureTest.php
@@ -137,4 +137,12 @@ class ServerProcedureTest extends PHPUnit_Framework_TestCase
         $server->bind('getAllC', new B, 'getAll');
         $server->executeProcedure('getAllC');
     }
+    /**
+     * @expectedException \JsonRPC\ResponseEncodingFailure
+     */
+    public function testInvalidResponse()
+    {
+        $server = new Server;
+        $server->getResponse([pack("H*", 'c32e')],array('id'=>1));
+    }
 }

--- a/tests/ServerProtocolTest.php
+++ b/tests/ServerProtocolTest.php
@@ -113,6 +113,22 @@ class ServerProtocolTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testInvalidResponse_MalformedCharacters()
+    {
+        $server = new Server('{"jsonrpc": "2.0", "method": "invalidresponse","id": 1}');
+
+        $invalidresponse = function() {
+            return pack("H*" ,'c32e');
+        };
+
+        $server->register('invalidresponse', $invalidresponse);
+
+        $this->assertEquals(
+            json_decode('{"jsonrpc": "2.0","id": 1, "error": {"code": -32603, "message": "Internal error","data": "Malformed UTF-8 characters, possibly incorrectly encoded"}}', true),
+            json_decode($server->execute(), true)
+        );
+    }
+
 
     public function testBatchInvalidJson()
     {


### PR DESCRIPTION
Return internal error (code -2603) when json_encode() is unable to encode response. (example: malformed UTF-8 encoding in response) 
+ unittests