### PR TITLE
Suppress errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -210,6 +210,9 @@ print_r($results);
 All results are stored at the same position of the call.
 
 ### Client exceptions
+Client exceptions are normally thrown when an error is returned by the server. You can change this behaviour by
+using the 'suppress_errors' option which causes exceptions to be returned. This can be extremely useful when
+executing the batch request. 
 
 - `BadFunctionCallException`: Procedure not found on the server
 - `InvalidArgumentException`: Wrong procedure arguments

--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -406,7 +406,7 @@ class Client
     private function getResult(array $payload)
     {
         if (isset($payload['error']['code'])) {
-            $this->handleRpcErrors($payload['error']);
+            return $this->handleRpcErrors($payload['error']);
         }
 
         return isset($payload['result']) ? $payload['result'] : null;

--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -60,6 +60,14 @@ class Client
     private $password;
 
     /**
+     * Do not immediately throw an exception on error. Return it instead.
+     *
+     * @access public
+     * @var boolean
+     */
+    private $suppress_errors = false;
+
+    /**
      * True for a batch request
      *
      * @access public
@@ -105,26 +113,20 @@ class Client
     public $ssl_verify_peer = true;
 
     /**
-     * Do not immediately throw an exception on error. Return it instead.
-     *
-     * @access public
-     * @var boolean
-     */
-    public $suppress_errors = false;
-
-    /**
      * Constructor
      *
      * @access public
-     * @param  string    $url         Server URL
-     * @param  integer   $timeout     HTTP timeout
-     * @param  array     $headers     Custom HTTP headers
+     * @param  string    $url                 Server URL
+     * @param  integer   $timeout             HTTP timeout
+     * @param  array     $headers             Custom HTTP headers
+     * @param  bool      $suppress_errors     Suppress exceptions
      */
-    public function __construct($url, $timeout = 3, $headers = array())
+    public function __construct($url, $timeout = 3, $headers = array(), $suppress_errors = false)
     {
         $this->url = $url;
         $this->timeout = $timeout;
         $this->headers = array_merge($this->headers, $headers);
+        $this->suppress_errors = !!$suppress_errors;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -100,6 +100,13 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $client->handleHttpErrors(array('HTTP/1.0 301 Moved Permantenly', 'Connection: close', 'HTTP/1.0 401 Unauthorized'));
     }
 
+    public function testSuppressException()
+    {
+        $client = new Client('http://localhost/', 3, array(), true);
+        $exception = $client->parseResponse(json_decode('{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null}', true));
+        $this->assertInstanceOf('\RuntimeException', $exception);
+    }
+
     public function testPrepareRequest()
     {
         $client = new Client('http://localhost/');


### PR DESCRIPTION
Client exceptions are normally thrown when an error is returned by the server. It's not so conviniet when working with the batch request, cause is some cases the error responses are OK. Now you can change this behaviour by using the 'suppress_errors' option which causes exceptions to be returned instead of thrown.