### PR TITLE
Move the handleHttpErrors method to get access to the error response

### DIFF
--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -320,14 +320,14 @@ class Client
         }
 
         $metadata = stream_get_meta_data($stream);
-        $this->handleHttpErrors($metadata['wrapper_data']);
-
         $response = json_decode(stream_get_contents($stream), true);
 
         if ($this->debug) {
             error_log('==> Request: '.PHP_EOL.json_encode($payload, JSON_PRETTY_PRINT));
             error_log('==> Response: '.PHP_EOL.json_encode($response, JSON_PRETTY_PRINT));
         }
+
+        $this->handleHttpErrors($metadata['wrapper_data']);
 
         return is_array($response) ? $response : array();
     }


### PR DESCRIPTION
I've been using this library to work with a blockchain fork's json-rpc interface. This interface throws error 500 + json errors if the call is wrong. At this time it's not possible to get that response, or override the method where this happens. 

By moving this call, it's possible to get the info when running in debug.