### PR TITLE
#46 - Make JsonRPC easier to extend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
     },
     "autoload": {
         "psr-0": {"JsonRPC": "src/"}
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.3"
     }
 }

--- a/src/JsonRPC/ProcedureHandler.php
+++ b/src/JsonRPC/ProcedureHandler.php
@@ -19,50 +19,50 @@ class ProcedureHandler
     /**
      * List of procedures
      *
-     * @access private
+     * @access protected
      * @var array
      */
-    private $callbacks = array();
+    protected $callbacks = array();
 
     /**
      * List of classes
      *
-     * @access private
+     * @access protected
      * @var array
      */
-    private $classes = array();
+    protected $classes = array();
 
     /**
      * List of instances
      *
-     * @access private
+     * @access protected
      * @var array
      */
-    private $instances = array();
+    protected $instances = array();
 
     /**
      * Method name to execute before the procedure
      *
-     * @access private
+     * @access protected
      * @var string
      */
-    private $before = '';
+    protected $before = '';
 
     /**
      * Username
      *
-     * @access private
+     * @access protected
      * @var string
      */
-    private $username;
+    protected $username;
 
     /**
      * Password
      *
-     * @access private
+     * @access protected
      * @var string
      */
-    private $password;
+    protected $password;
 
     /**
      * Set username

--- a/src/JsonRPC/Request/BatchRequestParser.php
+++ b/src/JsonRPC/Request/BatchRequestParser.php
@@ -34,6 +34,13 @@ class BatchRequestParser extends RequestParser
     /**
      * Return true if we have a batch request
      *
+     * ex : [
+     *   0 => '...',
+     *   1 => '...',
+     *   2 => '...',
+     *   3 => '...',
+     * ]
+     *
      * @static
      * @access public
      * @param  array $payload
@@ -41,6 +48,6 @@ class BatchRequestParser extends RequestParser
      */
     public static function isBatchRequest(array $payload)
     {
-        return is_array($payload) && array_keys($payload) === range(0, count($payload) - 1);
+        return array_keys($payload) === range(0, count($payload) - 1);
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -65,6 +65,78 @@ class ServerTest extends HeaderMockTest
         $this->assertEquals('{"jsonrpc":"2.0","result":7,"id":"1"}', $server->execute());
     }
 
+
+
+    public function testExecuteRequestParserOverride()
+    {
+        $requestParser = $this->getMockBuilder('JsonRPC\Request\RequestParser')
+            ->getMock();
+
+        $requestParser->method('withPayload')->willReturn($requestParser);
+        $requestParser->method('withProcedureHandler')->willReturn($requestParser);
+
+        $server = new Server($this->payload, array(), null, $requestParser);
+
+        $requestParser->expects($this->once())
+            ->method('parse');
+
+        $server->execute();
+    }
+
+    public function testExecuteBatchRequestParserOverride()
+    {
+        $batchRequestParser = $this->getMockBuilder('JsonRPC\Request\BatchRequestParser')
+            ->getMock();
+
+        $batchRequestParser->method('withPayload')->willReturn($batchRequestParser);
+        $batchRequestParser->method('withProcedureHandler')->willReturn($batchRequestParser);
+
+        $server = new Server('["...", "..."]', array(), null, null, $batchRequestParser);
+
+        $batchRequestParser->expects($this->once())
+            ->method('parse');
+
+        $server->execute();
+    }
+
+    public function testExecuteResponseBuilderOverride()
+    {
+        $responseBuilder = $this->getMockBuilder('JsonRPC\Response\ResponseBuilder')
+            ->getMock();
+
+        $responseBuilder->expects($this->once())
+            ->method('sendHeaders');
+
+        $server = new Server($this->payload, array(), $responseBuilder);
+        $server->execute();
+    }
+
+    public function testExecuteProcedureHandlerOverride()
+    {
+        $batchRequestParser = $this->getMockBuilder('JsonRPC\Request\BatchRequestParser')
+            ->getMock();
+
+        $procedureHandler = $this->getMockBuilder('JsonRPC\ProcedureHandler')
+            ->getMock();
+
+        $batchRequestParser->method('withPayload')->willReturn($batchRequestParser);
+        $batchRequestParser->method('withProcedureHandler')->willReturn($batchRequestParser);
+
+        $procedureHandler->method('withUsername')->willReturn($procedureHandler);
+        $procedureHandler->method('withPassword')->willReturn($procedureHandler);
+
+        $server = new Server('["...", "..."]', array(), null, null, $batchRequestParser, $procedureHandler);
+
+        $batchRequestParser->expects($this->once())
+            ->method('parse');
+
+        $batchRequestParser->expects($this->once())
+            ->method('withProcedureHandler')
+            ->with($this->identicalTo($procedureHandler));
+
+        $server->execute();
+    }
+
     public function testWhenCallbackRaiseForbiddenException()
     {
         $server = new Server($this->payload);


### PR DESCRIPTION
fguillot#46

* private properties & methods become protected ;
* RequestParser can be injected ;
* ResponseBuilder can be injected ;
* ProcedureHandler can be injected ;
* BatchRequestHandler can be injected ;
* Remove unecessary check in `JsonRPC\Request\BatchRequestParser::isBatchRequest` ;
* Add phpunit in require-dev.