### PR TITLE
Update HttpClient.php

### DIFF
--- a/src/JsonRPC/HttpClient.php
+++ b/src/JsonRPC/HttpClient.php
@@ -257,7 +257,7 @@ class HttpClient
         $response = json_decode(stream_get_contents($stream), true);
 
         if ($this->debug) {
-            error_log('==> Request: '.PHP_EOL.json_encode($payload, JSON_PRETTY_PRINT));
+            error_log('==> Request: '.PHP_EOL.(is_string($payload) ? $payload : json_encode($payload, JSON_PRETTY_PRINT)));
             error_log('==> Headers: '.PHP_EOL.var_export($headers, true));
             error_log('==> Response: '.PHP_EOL.json_encode($response, JSON_PRETTY_PRINT));
         }


### PR DESCRIPTION
The `$payload` value is not always an array.
If you run `json_encode` on a string all the quotes will be backslashed and the string is not a valid json anymore.