### PR TITLE
fix return exception in batches

### DIFF
--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -184,18 +184,9 @@ class Client
      */
     private function sendPayload($payload)
     {
-        try {
-
-            return ResponseParser::create()
-                ->withPayload($this->httpClient->execute($payload))
-                ->parse();
-
-        } catch (Exception $e) {
-            if ($this->returnException) {
-                return $e;
-            }
-
-            throw $e;
-        }
+        return ResponseParser::create()
+            ->withReturnException($this->returnException)
+            ->withPayload($this->httpClient->execute($payload))
+            ->parse();
     }
 }


### PR DESCRIPTION
Now, when you use batches and one of calls return exception (with returnException options true) whole response retrun this exception message. This pull request fix it.