### PR TITLE
Adds additional request attributes

### DIFF
--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -159,12 +159,13 @@ class Client
      * @param  array    $params      Procedure arguments
      * @return mixed
      */
-    public function execute($procedure, array $params = array())
+    public function execute($procedure, array $params = array(), array $reqattrs = array())
     {
         $payload = RequestBuilder::create()
             ->withProcedure($procedure)
             ->withParams($params)
-            ->build();
+            ->withRequestAttributes($reqattrs)
+            ->build($reqattrs);
 
         if ($this->isBatch) {
             $this->batch[] = $payload;

--- a/src/JsonRPC/Request/RequestBuilder.php
+++ b/src/JsonRPC/Request/RequestBuilder.php
@@ -35,6 +35,14 @@ class RequestBuilder
     private $params = array();
 
     /**
+     * Additional request attributes
+     *
+     * @access private
+     * @var array
+     */
+    private $reqattrs = array();
+
+    /**
      * Get new object instance
      *
      * @static
@@ -86,6 +94,19 @@ class RequestBuilder
     }
 
     /**
+     * Set additional request attributes
+     *
+     * @access public
+     * @param  array $reqattrs
+     * @return RequestBuilder
+     */
+    public function withRequestAttributes(array $reqattrs)
+    {
+        $this->reqattrs = $reqattrs;
+        return $this;
+    }
+
+    /**
      * Build the payload
      *
      * @access public
@@ -93,11 +114,11 @@ class RequestBuilder
      */
     public function build()
     {
-        $payload = array(
+        $payload = array_merge_recursive($this->reqattrs, array(
             'jsonrpc' => '2.0',
             'method' => $this->procedure,
             'id' => $this->id ?: mt_rand(),
-        );
+        ));
 
         if (! empty($this->params)) {
             $payload['params'] = $this->params;

--- a/tests/Request/RequestBuilderTest.php
+++ b/tests/Request/RequestBuilderTest.php
@@ -37,4 +37,17 @@ class RequestBuilderTest extends PHPUnit_Framework_TestCase
         $result = json_decode($payload, true);
         $this->assertNotNull($result['id']);
     }
+
+    public function testBuilderWithAdditionalRequestAttributes()
+    {
+        $payload = RequestBuilder::create()
+            ->withProcedure('foobar')
+            ->withParams(array(1, 2, 3))
+            ->withRequestAttributes(array("some-attr" => 42))
+            ->build();
+
+        $result = json_decode($payload, true);
+        $this->assertNotNull($result['some-attr']);
+    }
+
 }


### PR DESCRIPTION
These permits to have compatibility for systems that require
additional parameters in the request (superset of JSON-RPC 2.0).

An example of this is Zabbix, which requires an "auth" field in
API requests.