### PR TITLE
Changed ResponseBuilder members visibility from private to protected, reduced cyclomatic complexity of handleExceptions

### DIFF
--- a/src/JsonRPC/Response/ResponseBuilder.php
+++ b/src/JsonRPC/Response/ResponseBuilder.php
@@ -24,26 +24,26 @@ class ResponseBuilder
     /**
      * Payload ID
      *
-     * @access private
+     * @access protected
      * @var mixed
      */
-    private $id;
+    protected $id;
 
     /**
      * Payload ID
      *
-     * @access private
+     * @access protected
      * @var mixed
      */
-    private $result;
+    protected $result;
 
     /**
      * Payload error code
      *
-     * @access private
+     * @access protected
      * @var integer
      */
-    private $errorCode;
+    protected $errorCode;
 
     /**
      * Payload error message
@@ -51,41 +51,41 @@ class ResponseBuilder
      * @access private
      * @var string
      */
-    private $errorMessage;
+    protected $errorMessage;
 
     /**
      * Payload error data
      *
-     * @access private
+     * @access protected
      * @var mixed
      */
-    private $errorData;
+    protected $errorData;
 
     /**
      * HTTP Headers
      *
-     * @access private
+     * @access protected
      * @var array
      */
-    private $headers = array(
+    protected $headers = array(
         'Content-Type' => 'application/json',
     );
 
     /**
      * HTTP status
      *
-     * @access private
+     * @access protected
      * @var string
      */
-    private $status;
+    protected $status;
 
     /**
      * Exception
      *
-     * @access private
+     * @access protected
      * @var ResponseException
      */
-    private $exception;
+    protected $exception;
 
     /**
      * Get new object instance
@@ -240,10 +240,10 @@ class ResponseBuilder
     /**
      * Build response payload
      *
-     * @access private
+     * @access protected
      * @return array
      */
-    private function buildResponse()
+    protected function buildResponse()
     {
         $response = array('jsonrpc' => '2.0');
         $this->handleExceptions();
@@ -261,10 +261,10 @@ class ResponseBuilder
     /**
      * Build response error payload
      *
-     * @access private
+     * @access protected
      * @return array
      */
-    private function buildErrorResponse()
+    protected function buildErrorResponse()
     {
         $response = array(
             'code' => $this->errorCode,
@@ -281,42 +281,46 @@ class ResponseBuilder
     /**
      * Transform exceptions to JSON-RPC errors
      *
-     * @access private
+     * @access protected
      */
-    private function handleExceptions()
+    protected function handleExceptions()
     {
-        if ($this->exception instanceof InvalidJsonFormatException) {
+        try {
+            if ($this->exception instanceof Exception) {
+                throw $this->exception;
+            }
+        } catch (InvalidJsonFormatException $e) {
             $this->errorCode = -32700;
             $this->errorMessage = 'Parse error';
             $this->id = null;
-        } elseif ($this->exception instanceof InvalidJsonRpcFormatException) {
+        } catch (InvalidJsonRpcFormatException $e) {
             $this->errorCode = -32600;
             $this->errorMessage = 'Invalid Request';
             $this->id = null;
-        } elseif ($this->exception instanceof BadFunctionCallException) {
+        } catch (BadFunctionCallException $e) {
             $this->errorCode = -32601;
             $this->errorMessage = 'Method not found';
-        } elseif ($this->exception instanceof InvalidArgumentException) {
+        } catch (InvalidArgumentException $e) {
             $this->errorCode = -32602;
             $this->errorMessage = 'Invalid params';
-        } elseif ($this->exception instanceof ResponseEncodingFailureException) {
+        } catch (ResponseEncodingFailureException $e) {
             $this->errorCode = -32603;
             $this->errorMessage = 'Internal error';
             $this->errorData = $this->exception->getMessage();
-        } elseif ($this->exception instanceof AuthenticationFailureException) {
+        } catch (AuthenticationFailureException $e) {
             $this->errorCode = 401;
             $this->errorMessage = 'Unauthorized';
             $this->status = 'HTTP/1.0 401 Unauthorized';
             $this->withHeader('WWW-Authenticate', 'Basic realm="JsonRPC"');
-        } elseif ($this->exception instanceof AccessDeniedException) {
+        } catch (AccessDeniedException $e) {
             $this->errorCode = 403;
             $this->errorMessage = 'Forbidden';
             $this->status = 'HTTP/1.0 403 Forbidden';
-        } elseif ($this->exception instanceof ResponseException) {
+        } catch (ResponseException $e) {
             $this->errorCode = $this->exception->getCode();
             $this->errorMessage = $this->exception->getMessage();
             $this->errorData = $this->exception->getData();
-        } elseif ($this->exception instanceof Exception) {
+        } catch (Exception $e) {
             $this->errorCode = $this->exception->getCode();
             $this->errorMessage = $this->exception->getMessage();
         }


### PR DESCRIPTION
I'm trying to use your library to build JSON-RPC server. It looks very good and matches almost my needs. To extend it I use simple inheritance and override required methods. The only problem I have now is that all non-public members of ResponseBuilder are private, so I had to copy all the private members to my version of ResponseBuilder and change couple methods code.

If these private members were protected it would be much easier - e.g. I use all the class properties in the same way you do, but I can not access them in my class. So I changed visibility for all private members to protected to make inherited class much less.

Another change that I made is reducing cyclomatic complexity in handleExceptions - changed `elseif` blocks to `catch`.