### PR TITLE
Implement service classes, which allow easier management of larger API's

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,6 +67,11 @@ class Api
     {
         return $arg1 + $arg2;
     }
+
+    public function doSomething2($arg1, $arg2)
+    {
+        return $arg1 * $arg2;
+    }
 }
 
 $server = new Server();
@@ -83,6 +88,12 @@ $procedureHandler->withClassAndMethod('doSomething', 'Api');
 
 // Attach the class, the client will be able to call directly Api::doSomething()
 $procedureHandler->withObject(new Api());
+
+// Attach a class as a service, so the client can call all the classess public methods
+// Client Examples:
+// $client->execute('apiService.doSomething', [3]);
+// $client->execute('apiService.doSomething2', [3, 5]);
+$procedureHandler->withServiceClass('apiService', 'Api');
 
 echo $server->execute();
 

--- a/src/JsonRPC/Logger/DebugLogger.php
+++ b/src/JsonRPC/Logger/DebugLogger.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace JsonRPC\Logger;
+/**
+ * Created by PhpStorm.
+ * User: StevenLewis
+ * Date: 09/05/2017
+ * Time: 12:30
+ */
+class DebugLogger implements LoggerInterface
+{
+
+    /**
+     * recorded requests
+     * @var array
+     */
+    protected $logs = array();
+
+    public function log($id, $method, $params, $response, $timeTaken = 0, $metadata = array())
+    {
+        $this->logs[] = array(
+            'id'        => $id,
+            'method'    => $method,
+            'params'    => $params,
+            'response'  => $response,
+            'timeTaken' => $timeTaken,
+            'metadata'  => $metadata
+        );
+    }
+
+    public function getLogs()
+    {
+        return $this->logs;
+    }
+}

--- a/src/JsonRPC/Logger/LoggerInterface.php
+++ b/src/JsonRPC/Logger/LoggerInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace JsonRPC\Logger;
+/**
+ * Created by PhpStorm.
+ * User: StevenLewis
+ * Date: 09/05/2017
+ * Time: 12:27
+ */
+interface LoggerInterface
+{
+    /**
+     * Record a request
+     * metadata is for other useful information, i.e. processing time, call timestamp, server variables
+     *
+     * @param $id
+     * @param $method
+     * @param $params
+     * @param $response
+     * @param int $timeTaken
+     * @param array $metadata
+     * @return
+     */
+    public function log($id, $method, $params, $response, $timeTaken = 0, $metadata = array());
+}

--- a/src/JsonRPC/Logger/NullLogger.php
+++ b/src/JsonRPC/Logger/NullLogger.php
@@ -1,0 +1,15 @@
+<?php
+namespace JsonRPC\Logger;
+/**
+ * Created by PhpStorm.
+ * User: StevenLewis
+ * Date: 09/05/2017
+ * Time: 12:29
+ */
+class NullLogger implements LoggerInterface
+{
+
+    public function log($id, $method, $params, $response, $timeTaken = 0, $metadata = array())
+    {
+    }
+}

--- a/src/JsonRPC/Request/BatchRequestParser.php
+++ b/src/JsonRPC/Request/BatchRequestParser.php
@@ -26,6 +26,7 @@ class BatchRequestParser extends RequestParser
                 ->withProcedureHandler($this->procedureHandler)
                 ->withMiddlewareHandler($this->middlewareHandler)
                 ->withLocalException($this->localExceptions)
+                ->withLogger($this->logger)
                 ->parse();
         }
 

--- a/src/JsonRPC/Server.php
+++ b/src/JsonRPC/Server.php
@@ -4,6 +4,7 @@ namespace JsonRPC;
 
 use Closure;
 use Exception;
+use JsonRPC\Logger\LoggerInterface;
 use JsonRPC\Request\BatchRequestParser;
 use JsonRPC\Request\RequestParser;
 use JsonRPC\Response\ResponseBuilder;
@@ -117,16 +118,25 @@ class Server
     protected $batchRequestParser;
 
     /**
+     * Server call logger
+     *
+     * @access protected
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
      * Constructor
      *
      * @access public
-     * @param  string              $request
-     * @param  array               $server
-     * @param  ResponseBuilder     $responseBuilder
-     * @param  RequestParser       $requestParser
-     * @param  BatchRequestParser  $batchRequestParser
-     * @param  ProcedureHandler    $procedureHandler
-     * @param  MiddlewareHandler   $middlewareHandler
+     * @param  string $request
+     * @param  array $server
+     * @param  ResponseBuilder $responseBuilder
+     * @param  RequestParser $requestParser
+     * @param  BatchRequestParser $batchRequestParser
+     * @param  ProcedureHandler $procedureHandler
+     * @param  MiddlewareHandler $middlewareHandler
+     * @param LoggerInterface $logger
      */
     public function __construct(
         $request = '',
@@ -135,7 +145,8 @@ class Server
         RequestParser $requestParser = null,
         BatchRequestParser $batchRequestParser = null,
         ProcedureHandler $procedureHandler = null,
-        MiddlewareHandler $middlewareHandler = null
+        MiddlewareHandler $middlewareHandler = null,
+        LoggerInterface $logger = null
     ) {
         if ($request !== '') {
             $this->payload = json_decode($request, true);
@@ -149,6 +160,7 @@ class Server
         $this->batchRequestParser = $batchRequestParser ?: BatchRequestParser::create();
         $this->procedureHandler = $procedureHandler ?: new ProcedureHandler();
         $this->middlewareHandler = $middlewareHandler ?: new MiddlewareHandler();
+        $this->logger = $logger ?: new Logger\NullLogger();
     }
 
     /**
@@ -330,7 +342,7 @@ class Server
 
     /**
      * Handle exceptions
-     * 
+     *
      * @access protected
      * @param  Exception $e
      * @return string
@@ -361,6 +373,7 @@ class Server
                 ->withProcedureHandler($this->procedureHandler)
                 ->withMiddlewareHandler($this->middlewareHandler)
                 ->withLocalException($this->localExceptions)
+                ->withLogger($this->logger)
                 ->parse();
         }
 
@@ -369,6 +382,7 @@ class Server
             ->withProcedureHandler($this->procedureHandler)
             ->withMiddlewareHandler($this->middlewareHandler)
             ->withLocalException($this->localExceptions)
+            ->withLogger($this->logger)
             ->parse();
     }
 

--- a/tests/ProcedureHandlerTest.php
+++ b/tests/ProcedureHandlerTest.php
@@ -10,6 +10,16 @@ class A
     {
         return $p1 + $p2 + $p3;
     }
+
+    public function add($a, $b)
+    {
+        return $a + $b;
+    }
+
+    public function subtract($a, $b)
+    {
+        return $a - $b;
+    }
 }
 
 class B
@@ -17,6 +27,16 @@ class B
     public function getAll($p1)
     {
         return $p1 + 2;
+    }
+
+    public function add($a, $b)
+    {
+        return $a + $b;
+    }
+
+    public function subtract($a, $b)
+    {
+        return $a - $b;
     }
 }
 
@@ -87,10 +107,21 @@ class ProcedureHandlerTest extends PHPUnit_Framework_TestCase
         $handler->withClassAndMethod('getAllA', 'A', 'getAll');
         $handler->withClassAndMethod('getAllB', 'B', 'getAll');
         $handler->withClassAndMethod('getAllC', new B, 'getAll');
+        $handler->withServiceClass('serviceA', 'A');
+        $handler->withServiceClass('serviceB', new B());
         $this->assertEquals(6, $handler->executeProcedure('getAllA', array('p2' => 4, 'p1' => -2)));
         $this->assertEquals(10, $handler->executeProcedure('getAllA', array('p2' => 4, 'p3' => 8, 'p1' => -2)));
         $this->assertEquals(6, $handler->executeProcedure('getAllB', array('p1' => 4)));
         $this->assertEquals(5, $handler->executeProcedure('getAllC', array('p1' => 3)));
+
+        $this->assertEquals(5, $handler->executeProcedure('serviceA.add', array('b' => 3, 'a' => 2)));
+        $this->assertEquals(2, $handler->executeProcedure('serviceA.subtract', array('b' => 3, 'a' => 5)));
+        $this->assertEquals(6, $handler->executeProcedure('serviceA.getAll', array('p2' => 4, 'p1' => -2)));
+        $this->assertEquals(10, $handler->executeProcedure('serviceA.getAll', array('p2' => 4, 'p3' => 8, 'p1' => -2)));
+
+        $this->assertEquals(5, $handler->executeProcedure('serviceB.add', array('b' => 3, 'a' => 2)));
+        $this->assertEquals(2, $handler->executeProcedure('serviceB.subtract', array('b' => 3, 'a' => 5)));
+        $this->assertEquals(6, $handler->executeProcedure('serviceB.getAll', array('p1' => 4)));
     }
 
     public function testBindPositionalArguments()
@@ -98,9 +129,20 @@ class ProcedureHandlerTest extends PHPUnit_Framework_TestCase
         $handler = new ProcedureHandler;
         $handler->withClassAndMethod('getAllA', 'A', 'getAll');
         $handler->withClassAndMethod('getAllB', 'B', 'getAll');
+        $handler->withServiceClass('serviceA', 'A');
+        $handler->withServiceClass('serviceB', new B());
         $this->assertEquals(6, $handler->executeProcedure('getAllA', array(4, -2)));
         $this->assertEquals(2, $handler->executeProcedure('getAllA', array(4, 0, -2)));
         $this->assertEquals(4, $handler->executeProcedure('getAllB', array(2)));
+
+        $this->assertEquals(5, $handler->executeProcedure('serviceA.add', array(2, 3)));
+        $this->assertEquals(2, $handler->executeProcedure('serviceA.subtract', array(5, 3)));
+        $this->assertEquals(6, $handler->executeProcedure('serviceA.getAll', array(4, -2)));
+        $this->assertEquals(2, $handler->executeProcedure('serviceA.getAll', array(4, 0, -2)));
+
+        $this->assertEquals(5, $handler->executeProcedure('serviceB.add', array(2, 3)));
+        $this->assertEquals(2, $handler->executeProcedure('serviceB.subtract', array(5, 3)));
+        $this->assertEquals(4, $handler->executeProcedure('serviceB.getAll', array(2)));
     }
 
     public function testRegisterNamedArguments()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -279,7 +279,7 @@ class ServerTest extends HeaderMockTest
         $logger = new DummyLogger();
         $server = new Server(
             $this->payload,
-            [],
+            array(),
             null,
             null,
             null,
@@ -318,7 +318,7 @@ class ServerTest extends HeaderMockTest
         $logger = new DummyLogger();
         $server = new Server(
             $this->payload,
-            [],
+            array(),
             null,
             null,
             null,


### PR DESCRIPTION
This allows full classes be published to a namespace in the API.

It has method safety checks, so won't allow the following methods to run:

- public methods starting with underscore(_)  to run i.e constructors, deconstructors and class magic methods
- Private or protected methods
- internal methods i.e if a service class that extends a php internal class

