### PR TITLE
Introduced ExceptionTypeHierarchy

### DIFF
--- a/src/JsonRPC/Exception/AccessDeniedException.php
+++ b/src/JsonRPC/Exception/AccessDeniedException.php
@@ -2,14 +2,12 @@
 
 namespace JsonRPC\Exception;
 
-use Exception;
-
 /**
  * Class AccessDeniedException
  *
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class AccessDeniedException extends Exception
+class AccessDeniedException extends RpcCallFailedException
 {
 }

--- a/src/JsonRPC/Exception/AuthenticationFailureException.php
+++ b/src/JsonRPC/Exception/AuthenticationFailureException.php
@@ -2,14 +2,12 @@
 
 namespace JsonRPC\Exception;
 
-use Exception;
-
 /**
  * Class AuthenticationFailureException
  *
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class AuthenticationFailureException extends Exception
+class AuthenticationFailureException extends RpcCallFailedException
 {
 }

--- a/src/JsonRPC/Exception/InvalidJsonFormatException.php
+++ b/src/JsonRPC/Exception/InvalidJsonFormatException.php
@@ -2,14 +2,12 @@
 
 namespace JsonRPC\Exception;
 
-use Exception;
-
 /**
  * Class InvalidJsonFormatException
  *
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class InvalidJsonFormatException extends Exception
+class InvalidJsonFormatException extends RpcCallFailedException
 {
 }

--- a/src/JsonRPC/Exception/InvalidJsonRpcFormatException.php
+++ b/src/JsonRPC/Exception/InvalidJsonRpcFormatException.php
@@ -2,14 +2,12 @@
 
 namespace JsonRPC\Exception;
 
-use Exception;
-
 /**
  * Class InvalidJsonRpcFormatException
  *
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class InvalidJsonRpcFormatException extends Exception
+class InvalidJsonRpcFormatException extends RpcCallFailedException
 {
 }

--- a/src/JsonRPC/Exception/ResponseEncodingFailureException.php
+++ b/src/JsonRPC/Exception/ResponseEncodingFailureException.php
@@ -2,14 +2,12 @@
 
 namespace JsonRPC\Exception;
 
-use Exception;
-
 /**
  * Class ResponseEncodingFailureException
  *
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class ResponseEncodingFailureException extends Exception
+class ResponseEncodingFailureException extends RpcCallFailedException
 {
 }

--- a/src/JsonRPC/Exception/ResponseException.php
+++ b/src/JsonRPC/Exception/ResponseException.php
@@ -10,7 +10,7 @@ use Exception;
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class ResponseException extends Exception
+class ResponseException extends RpcCallFailedException
 {
     /**
      * A value that contains additional information about the error.

--- a/src/JsonRPC/Exception/RpcCallFailedException.php
+++ b/src/JsonRPC/Exception/RpcCallFailedException.php
@@ -2,12 +2,14 @@
 
 namespace JsonRPC\Exception;
 
+use Exception;
+
 /**
- * Class ConnectionFailureException
+ * Class AccessDeniedException
  *
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class ConnectionFailureException extends RpcCallFailedException
+class RpcCallFailedException extends Exception
 {
 }

--- a/src/JsonRPC/Exception/ServerErrorException.php
+++ b/src/JsonRPC/Exception/ServerErrorException.php
@@ -2,14 +2,12 @@
 
 namespace JsonRPC\Exception;
 
-use Exception;
-
 /**
  * Class ServerErrorException
  *
  * @package JsonRPC\Exception
  * @author  Frederic Guillot
  */
-class ServerErrorException extends Exception
+class ServerErrorException extends RpcCallFailedException
 {
 }


### PR DESCRIPTION
Added an Exception-BaseClass, all other domain specific Exceptions extend it.
The upside is that you can explicitly catch all RPC-related Exceptions.
IMHO it is generally safer, than an generic `catch(\Exception $e)`.