### PR TITLE
function to en/disable argument count check

### DIFF
--- a/src/JsonRPC/ProcedureHandler.php
+++ b/src/JsonRPC/ProcedureHandler.php
@@ -48,6 +48,37 @@ class ProcedureHandler
      */
     protected $beforeMethodName = '';
 
+     /**
+     * Check minimum argument count
+     *
+     * @access protected
+     * @var boolean
+     */
+    protected $checkMinArgCount = true;
+
+     /**
+     * Check maximum argument count
+     *
+     * @access protected
+     * @var boolean
+     */
+    protected $checkMaxArgCount = true;
+
+    /**
+     * Set if argument count should be checked
+     *
+     * @access public
+     * @param  boolean  $checkMin       Check minimum count
+     * @param  boolean  $checkMax       Check maximum count
+     * @return $this
+     */    
+    public function setCheckArgumentsCount($checkMin,$checkMax)
+    {
+     $this->checkMinArgCount=$checkMin;
+     $this->checkMaxArgCount=$checkMax;
+     return $this;
+    }
+    
     /**
      * Register a new procedure
      *
@@ -208,11 +239,11 @@ class ProcedureHandler
     {
         $nbParams = count($requestParams);
 
-        if ($nbParams < $nbRequiredParams) {
+        if (($this->checkMinArgCount) && ($nbParams < $nbRequiredParams)) {
             throw new InvalidArgumentException('Wrong number of arguments');
         }
 
-        if ($nbParams > $nbMaxParams) {
+        if (($this->checkMaxArgCount) && ($nbParams > $nbMaxParams)) {
             throw new InvalidArgumentException('Too many arguments');
         }
 


### PR DESCRIPTION
Sometimes I need to pass more arguments in the RPC call, check the basic parameters in PHP and then work with the rest of JSON data in the plpgsql. Then I need to disable $nbParams > $nbMaxParams check.   When I pass more arguments, the check nbParams < $nbRequiredParams  is useless, it still doesn't guarantee that you are passing all required params (this is done in getNamedArguments()), so you can also disable this check ...